### PR TITLE
Updates on YALTF during hackathon.lu 2025

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,7 @@ type Target struct {
 
 type CommonOpts struct {
 	SSHKeyPath string `toml:"sshkeypath"`
+	SSHTimeout int    `toml:"timeout_seconds"`
 }
 
 // Targets represents the computers that will be scanned.

--- a/models/models.go
+++ b/models/models.go
@@ -65,5 +65,5 @@ type ScanResult struct {
 	Version   string       `json:"version"`
 	ScannedAt string       `json:"scannedAt"`
 	Results   LicenseInfos `json:"results"`
-	Errors    Errors       `json:"errors,omitempty"`
+	Errors    TargetErrors `json:"errors,omitempty"`
 }

--- a/models/models.go
+++ b/models/models.go
@@ -66,5 +66,5 @@ type ScanResult struct {
 	ScanMode  string       `json:"scanMode"`
 	ScannedAt string       `json:"scannedAt"`
 	Results   LicenseInfos `json:"results"`
-	Errors    Errors       `json:"errors,omitempty"`
+	Errors    TargetErrors `json:"errors,omitempty"`
 }

--- a/models/models.go
+++ b/models/models.go
@@ -63,5 +63,5 @@ type ScanResult struct {
 	Version   string       `json:"version"`
 	ScannedAt string       `json:"scannedAt"`
 	Results   LicenseInfos `json:"results"`
-	Errors    Errors       `json:"errors"`
+	Errors    Errors       `json:"errors,omitempty"`
 }

--- a/models/models.go
+++ b/models/models.go
@@ -63,6 +63,7 @@ type SingleError struct {
 
 type ScanResult struct {
 	Version   string       `json:"version"`
+	ScanMode  string       `json:"scanMode"`
 	ScannedAt string       `json:"scannedAt"`
 	Results   LicenseInfos `json:"results"`
 	Errors    TargetErrors `json:"errors,omitempty"`

--- a/models/models.go
+++ b/models/models.go
@@ -51,8 +51,10 @@ type Error struct {
 	Message string     `json:"message"`
 }
 
-// Errors holds target, Error pairs
-type Errors map[string]Error
+type Errors []Error
+
+// TargetErrors holds all errors occurred on targets
+type TargetErrors map[string]Errors
 
 type SingleError struct {
 	TargetName string
@@ -63,5 +65,5 @@ type ScanResult struct {
 	Version   string       `json:"version"`
 	ScannedAt string       `json:"scannedAt"`
 	Results   LicenseInfos `json:"results"`
-	Errors    Errors       `json:"errors,omitempty"`
+	Errors    TargetErrors `json:"errors,omitempty"`
 }

--- a/models/models.go
+++ b/models/models.go
@@ -66,5 +66,5 @@ type ScanResult struct {
 	ScanMode  string       `json:"scanMode"`
 	ScannedAt string       `json:"scannedAt"`
 	Results   LicenseInfos `json:"results"`
-	Errors    TargetErrors `json:"errors,omitempty"`
+	Errors    Errors       `json:"errors,omitempty"`
 }

--- a/models/models.go
+++ b/models/models.go
@@ -65,5 +65,5 @@ type ScanResult struct {
 	Version   string       `json:"version"`
 	ScannedAt string       `json:"scannedAt"`
 	Results   LicenseInfos `json:"results"`
-	Errors    TargetErrors `json:"errors,omitempty"`
+	Errors    Errors       `json:"errors,omitempty"`
 }

--- a/models/models.go
+++ b/models/models.go
@@ -6,7 +6,12 @@
 
 package models
 
-// LicenseInfo holds package, license pairs.
+import (
+	"encoding/json"
+	"time"
+)
+
+// LicenseInfo holds (package, license) pairs.
 type LicenseInfo map[string]string
 
 type SingleResult struct {
@@ -17,8 +22,46 @@ type SingleResult struct {
 // LicenseInfos holds target, LicenseInfo pairs.
 type LicenseInfos map[string]LicenseInfo
 
+type ErrorLevel int
+
+const (
+	Warning ErrorLevel = iota
+	Critical
+)
+
+func (el ErrorLevel) String() string {
+	switch el {
+	case Warning:
+		return "Warning"
+	case Critical:
+		return "Critical"
+	default:
+		return "Invalid Error Level"
+	}
+}
+
+func (el ErrorLevel) MarshalJSON() ([]byte, error) {
+	// It is assumed Suit implements fmt.Stringer.
+	return json.Marshal(el.String())
+}
+
+type Error struct {
+	Time    time.Time  `json:"time"`
+	Level   ErrorLevel `json:"severity"`
+	Message string     `json:"message"`
+}
+
+// Errors holds target, Error pairs
+type Errors map[string]Error
+
+type SingleError struct {
+	TargetName string
+	Error      Error
+}
+
 type ScanResult struct {
 	Version   string       `json:"version"`
 	ScannedAt string       `json:"scannedAt"`
 	Results   LicenseInfos `json:"results"`
+	Errors    Errors       `json:"errors"`
 }

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -27,7 +27,7 @@ func WriteResults(scanResult *models.ScanResult) {
 		return
 	}
 
-	fileName := fmt.Sprintf("%s.json", scanResult.ScannedAt)
+	fileName := fmt.Sprintf("%s-%ss.json", scanResult.ScannedAt, scanResult.ScanMode)
 
 	err = os.Mkdir("results", os.ModePerm)
 

--- a/scanner/dpkg.go
+++ b/scanner/dpkg.go
@@ -3,7 +3,7 @@ package scanner
 // Compacted form of the code developed by Daniel Alder
 // https://github.com/daald/dpkg-licenses
 
-var dpkg_cmd = `
+var dpkg_name_lic = `
 set -e
 
 machine_readable () {

--- a/scanner/dpkg.go
+++ b/scanner/dpkg.go
@@ -1,0 +1,160 @@
+package scanner
+
+// Compacted form of the code developed by Daniel Alder
+// https://github.com/daald/dpkg-licenses
+
+var dpkg_cmd = `
+set -e
+
+machine_readable () {
+  package="$1"
+  copyrightfile=
+  if [ -f "/usr/share/doc/$package/copyright" ]; then
+    copyrightfile="/usr/share/doc/$package/copyright"
+  elif [ -f "/usr/share/doc/${package%:*}/copyright" ]; then
+    copyrightfile="/usr/share/doc/${package%:*}/copyright"
+  else
+    exit 0  # no copyright file found
+  fi
+
+  format=$(awk '/^Format:/{print}/^$/{exit}' "$copyrightfile")
+  [ -n "$format" ] || exit 0
+
+  case "$format" in
+    *'//www.debian.org/doc/packaging-manuals/copyright-format/1.0'*)
+      result=$(grep '^License:' "$copyrightfile" | cut -d':' -f2-)
+      ;;
+    *'//dep.debian.net/deps/dep5'*)
+      result=$(grep '^License:' "$copyrightfile" | cut -d':' -f2-)
+      ;;
+    *'//anonscm.debian.org/viewvc/dep/web/deps/dep5.mdwn?'*)
+      result=$(grep '^License:' "$copyrightfile" | cut -d':' -f2-)
+      ;;
+    *'//svn.debian.org/wsvn/dep/web/deps/dep5.mdwn?'*)
+      result=$(grep '^License:' "$copyrightfile" | cut -d':' -f2-)
+      ;;
+    *'//anonscm.debian.org/loggerhead/dep/dep5/trunk/annotate/179/dep5/copyright-format.xml'*)
+      result=$(grep '^License:' "$copyrightfile" | cut -d':' -f2-)
+      ;;
+    "Format:")  # seen in /usr/share/doc/libpcsclite1/copyright
+      result=$(grep '^License:' "$copyrightfile" | cut -d':' -f2-)
+      ;;
+    *)
+      echo "WARNING: Unknown format of $copyrightfile: $format" >&2
+      exit 1  # unknown format
+  esac
+
+  if [ -n "$result" ]; then
+    echo "$result" | sed -r -e 's/ and /\n/g' -e 's/^ +//' -e 's/ +$//' -e 's/icence/icense/g' | sort -u
+  fi
+
+  exit 0
+}
+
+fuzzy_common_licenses () {
+  set -e
+
+  package="$1"
+  copyrightfile=
+  if [ -f "/usr/share/doc/$package/copyright" ]; then
+    copyrightfile="/usr/share/doc/$package/copyright"
+  elif [ -f "/usr/share/doc/${package%:*}/copyright" ]; then
+    copyrightfile="/usr/share/doc/${package%:*}/copyright"
+  else
+    exit 0  # no copyright file found
+  fi
+
+  result=$(grep -oP '/usr/share/common-licenses/[0-9A-Za-z_.+-]+[0-9A-Za-z+]' "$copyrightfile" | cut -d/ -f5- | sort -u)
+  if [ -n "$result" ]; then
+    echo "$result"
+  fi
+
+  exit 0
+}
+
+superfuzzy () {
+  set -e
+
+  package="$1"
+  copyrightfile=
+  if [ -f "/usr/share/doc/$package/copyright" ]; then
+    copyrightfile="/usr/share/doc/$package/copyright"
+  elif [ -f "/usr/share/doc/${package%:*}/copyright" ]; then
+    copyrightfile="/usr/share/doc/${package%:*}/copyright"
+  else
+    exit 0  # no copyright file found
+  fi
+
+  result=$(grep -Ewoi \
+      -e '(4-?clause )?"?BSD"? licen[sc]es?' \
+      -e '(Boost Software|mozilla (public)?|MIT) Licen[sc]es?' \
+      -e '(CCPL|BSD|L?GPL)-[0-9a-z.+-]+( Licenses?)?' \
+      -e 'Creative Commons( Licenses?)?' \
+      -e 'Public Domain( Licenses?)?' \
+      -e 'GNU General Public( License)?' \
+      -e 'Info-ZIP License' \
+      "$copyrightfile" | sed -r -e 's/[Ll]icence/License/g' | sort -u)
+  if [ -n "$result" ]; then
+    echo "$result"
+  fi
+
+  exit 0
+}
+
+free_licence () {
+  set -e
+
+  package="$1"
+  copyrightfile=
+  if [ -f "/usr/share/doc/$package/copyright" ]; then
+    copyrightfile="/usr/share/doc/$package/copyright"
+  elif [ -f "/usr/share/doc/${package%:*}/copyright" ]; then
+    copyrightfile="/usr/share/doc/${package%:*}/copyright"
+  else
+    exit 0  # no copyright file found
+  fi
+
+  result=$(grep -e '^License:' -e '^Licence:' "$copyrightfile" | cut -d':' -f2-)
+  if [ -n "$result" ]; then
+    echo "$result" | sed -r -e 's/ and /\n/g' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e 's/icence/icense/g' | sort -u
+  fi
+
+  exit 0
+}
+
+dump_unreadable () {
+  set -e
+
+  package="$1"
+  copyrightfile=
+  if [ -f "/usr/share/doc/$package/copyright" ]; then
+    copyrightfile="/usr/share/doc/$package/copyright"
+  elif [ -f "/usr/share/doc/${package%:*}/copyright" ]; then
+    copyrightfile="/usr/share/doc/${package%:*}/copyright"
+  else
+    exit 0  # no copyright file found
+  fi
+
+  #echo "$copyrightfile" >&2
+  #head -n1 "$copyrightfile" >&2
+
+  exit 0
+}
+
+methods=(machine_readable fuzzy_common_licenses superfuzzy free_licence dump_unreadable)
+
+COLUMNS=2000 dpkg -l | grep '^.[iufhwt]' | while read pState package pVer pArch pDesc; do
+  license=
+  for method in $methods; do
+    license=$("$method" "$package")
+    [ $? -eq 0 ] || exit 1
+    [ -n "$license" ] || continue
+    # remove line breaks and spaces
+    license=$(echo "$license" | tr '\n' ' ' | sed -r -e 's/ +/ /g' -e 's/^ +//' -e 's/ +$//')
+    [ -z "$license" ] || break
+  done
+  [ -n "$license" ] || license='unknown'
+
+  printf "$package $license\n"
+done
+`

--- a/scanner/parser.go
+++ b/scanner/parser.go
@@ -29,3 +29,21 @@ func parseRPM(stdout string, licenseInfo models.LicenseInfo) {
 		licenseInfo[name] = license
 	}
 }
+
+func parseWIN(stdout string, licenseInfo models.LicenseInfo) {
+	lines := strings.Split(stdout, "\n")
+
+	for _, line := range lines {
+		// Examples for line:
+		// samba-common GPL-3.0-or-later AND LGPL-3.0-or-later
+		// intel-audio-firmware LicenseRef-Callaway-Redistributable-no-modification-permitted
+		trimmed := strings.TrimSpace(line)
+		name, license, found := strings.Cut(trimmed, "|&|")
+
+		if !found {
+			continue
+		}
+
+		licenseInfo[name] = license
+	}
+}

--- a/scanner/parser.go
+++ b/scanner/parser.go
@@ -47,3 +47,22 @@ func parseWIN(stdout string, licenseInfo models.LicenseInfo) {
 		licenseInfo[name] = license
 	}
 }
+
+func parseDPKG(stdout string, licenseInfo models.LicenseInfo) {
+	lines := strings.Split(stdout, "\n")
+
+	for _, line := range lines {
+		// Examples for line:
+		// busybox 1:1.35.0-4+b3 unknown
+		// bzip2 1.0.8-5+b1 BSD-variant GPL-2
+		// ca-certificates 20230311 GPL-2+ MPL-2.0
+		trimmed := strings.TrimSpace(line)
+		name, license, found := strings.Cut(trimmed, " ")
+
+		if !found {
+			continue
+		}
+
+		licenseInfo[name] = license
+	}
+}

--- a/scanner/parser.go
+++ b/scanner/parser.go
@@ -30,24 +30,6 @@ func parseRPM(stdout string, licenseInfo models.LicenseInfo) {
 	}
 }
 
-func parseWIN(stdout string, licenseInfo models.LicenseInfo) {
-	lines := strings.Split(stdout, "\n")
-
-	for _, line := range lines {
-		// Examples for line:
-		// samba-common GPL-3.0-or-later AND LGPL-3.0-or-later
-		// intel-audio-firmware LicenseRef-Callaway-Redistributable-no-modification-permitted
-		trimmed := strings.TrimSpace(line)
-		name, license, found := strings.Cut(trimmed, "|&|")
-
-		if !found {
-			continue
-		}
-
-		licenseInfo[name] = license
-	}
-}
-
 func parseDPKG(stdout string, licenseInfo models.LicenseInfo) {
 	lines := strings.Split(stdout, "\n")
 
@@ -58,6 +40,24 @@ func parseDPKG(stdout string, licenseInfo models.LicenseInfo) {
 		// ca-certificates 20230311 GPL-2+ MPL-2.0
 		trimmed := strings.TrimSpace(line)
 		name, license, found := strings.Cut(trimmed, " ")
+
+		if !found {
+			continue
+		}
+
+		licenseInfo[name] = license
+	}
+}
+
+func parseWIN(stdout string, licenseInfo models.LicenseInfo) {
+	lines := strings.Split(stdout, "\n")
+
+	for _, line := range lines {
+		// Examples for line:
+		// samba-common GPL-3.0-or-later AND LGPL-3.0-or-later
+		// intel-audio-firmware LicenseRef-Callaway-Redistributable-no-modification-permitted
+		trimmed := strings.TrimSpace(line)
+		name, license, found := strings.Cut(trimmed, "|&|")
 
 		if !found {
 			continue

--- a/scanner/parser.go
+++ b/scanner/parser.go
@@ -35,9 +35,9 @@ func parseDPKG(stdout string, licenseInfo models.LicenseInfo) {
 
 	for _, line := range lines {
 		// Examples for line:
-		// busybox 1:1.35.0-4+b3 unknown
-		// bzip2 1.0.8-5+b1 BSD-variant GPL-2
-		// ca-certificates 20230311 GPL-2+ MPL-2.0
+		// busybox unknown
+		// bzip2 BSD-variant GPL-2
+		// ca-certificates GPL-2+ MPL-2.0
 		trimmed := strings.TrimSpace(line)
 		name, license, found := strings.Cut(trimmed, " ")
 

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -25,6 +25,7 @@ import (
 
 type Scanner struct {
 	Targets     map[string]config.Target
+	Timeout     time.Duration
 	VersionOnly bool
 }
 
@@ -51,7 +52,7 @@ func (s Scanner) Scan() error {
 
 	for name, target := range s.Targets {
 		wg.Add(1)
-		go scanTarget(name, target, s.VersionOnly)
+		go scanTarget(name, target, s.Timeout, s.VersionOnly)
 	}
 
 	go s.collectResults(&scanResult)
@@ -63,7 +64,7 @@ func (s Scanner) Scan() error {
 	return nil
 }
 
-func scanTarget(name string, target config.Target, versionOnly bool) {
+func scanTarget(name string, target config.Target, timeout time.Duration, versionOnly bool) {
 	defer wg.Done()
 
 	if versionOnly {
@@ -93,7 +94,7 @@ func scanTarget(name string, target config.Target, versionOnly bool) {
 			ssh.PublicKeys(key),
 		},
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		Timeout:         5 * time.Second,
+		Timeout:         timeout * time.Second,
 	}
 
 	address := net.JoinHostPort(target.Host, target.Port)

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -112,6 +112,30 @@ func scanTarget(name string, target config.Target) {
 		}
 
 		parseRPM(string(output), licenseInfo)
+	case "debian", "ubuntu":
+		message := fmt.Sprintf("Debian based OSs are not supported yet: %s", targetOS)
+		slog.Error(message)
+
+		singleError := models.SingleError{TargetName: name, Error: models.Error{Time: time.Now(), Level: models.Critical, Message: message}}
+		errorsCh <- singleError
+	case "windows":
+		message := fmt.Sprintf("Detected OS: %s", targetOS)
+		slog.Info(message)
+
+		output, err := runCommand(client, `foreach ($UKey in 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*','HKLM:\SOFTWARE\Wow6432node\Microsoft\Windows\CurrentVersion\Uninstall\*','HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*','HKCU:\SOFTWARE\Wow6432node\Microsoft\Windows\CurrentVersion\Uninstall\*'){foreach ($Product in (Get-ItemProperty $UKey -ErrorAction SilentlyContinue)){if($Product.DisplayName -and $Product.SystemComponent -ne 0){$Product.DisplayName + "|&|" + $Product.DisplayVersion}}}`)
+
+		if err != nil {
+			slog.Error("Failed to query packages.")
+			return
+		}
+
+		parseWIN(string(output), licenseInfo)
+	case "macos":
+		message := fmt.Sprintf("MacOS is not supported yet: %s", targetOS)
+		slog.Error(message)
+
+		singleError := models.SingleError{TargetName: name, Error: models.Error{Time: time.Now(), Level: models.Critical, Message: message}}
+		errorsCh <- singleError
 	default:
 		message := fmt.Sprintf("Unsupported OS: %s", targetOS)
 		slog.Error(message)
@@ -159,8 +183,21 @@ func getTargetOS(client *ssh.Client) string {
 	output, err := runCommand(client, "cat /etc/os-release")
 
 	if err != nil {
-		slog.Error("Failed to read /etc/os-release.", "error", err.Error())
-		return "Unknown"
+		// check for windows
+		output, err2 := runCommand(client, "systeminfo")
+		if err2 != nil {
+			// TODO check for mac else unknown
+			slog.Error("Unknown OS.", "error", err2.Error())
+			return "Unknown"
+		}
+		lines := strings.Split(string(output), "\n")
+		for _, line := range lines {
+			if strings.Contains(line, "Windows") {
+				// slog.Info("Found Windows OS")
+				return "windows"
+			}
+		}
+
 	}
 
 	lines := strings.Split(string(output), "\n")

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -37,7 +37,7 @@ func (s Scanner) Scan() error {
 		Version:   config.Version,
 		ScannedAt: time.Now().Format("2006-01-02T15:04:05"),
 		Results:   make(models.LicenseInfos),
-		Errors:    make(models.Errors),
+		Errors:    make(models.TargetErrors),
 	}
 
 	resultsCh = make(chan models.SingleResult, len(s.Targets))
@@ -113,11 +113,31 @@ func scanTarget(name string, target config.Target) {
 
 		parseRPM(string(output), licenseInfo)
 	case "debian", "ubuntu":
-		message := fmt.Sprintf("Debian based OSs are not supported yet: %s", targetOS)
-		slog.Error(message)
+		message := fmt.Sprintf("Detected OS: %s", targetOS)
+		slog.Info(message)
 
-		singleError := models.SingleError{TargetName: name, Error: models.Error{Time: time.Now(), Level: models.Critical, Message: message}}
-		errorsCh <- singleError
+		output, err := runCommand(client, dpkg_cmd)
+
+		if err != nil {
+			slog.Error("Failed to query packages.")
+			return
+		}
+
+		parseDPKG(string(output), licenseInfo)
+
+		failed := 0
+		for _, license := range licenseInfo {
+			if license == "unknown" {
+				failed += 1
+			}
+		}
+
+		warningMsg := fmt.Sprintf("Failed to identify licenses of %d out of %d packages (%.0f%% accuracy).", failed, len(licenseInfo), 100.0*(1-float64(failed)/float64(len(licenseInfo))))
+
+		if failed > 0 {
+			singleError := models.SingleError{TargetName: name, Error: models.Error{Time: time.Now(), Level: models.Warning, Message: warningMsg}}
+			errorsCh <- singleError
+		}
 	case "windows":
 		message := fmt.Sprintf("Detected OS: %s", targetOS)
 		slog.Info(message)
@@ -157,7 +177,7 @@ func (s Scanner) collectResults(scanResult *models.ScanResult) {
 
 func (s Scanner) collectErrors(scanResult *models.ScanResult) {
 	for scanError := range errorsCh {
-		scanResult.Errors[scanError.TargetName] = scanError.Error
+		scanResult.Errors[scanError.TargetName] = append(scanResult.Errors[scanError.TargetName], scanError.Error)
 	}
 }
 

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -101,6 +101,7 @@ func scanTarget(name string, target config.Target, versionOnly bool) {
 	if err != nil {
 		slog.Error("Connection failed.", "host", target.Host, "error", err)
 		resultsCh <- models.SingleResult{TargetName: name}
+		errorsCh <- models.SingleError{TargetName: name, Error: models.Error{Time: time.Now(), Level: models.Critical, Message: err.Error()}}
 		return
 	}
 

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -66,7 +66,11 @@ func (s Scanner) Scan() error {
 func scanTarget(name string, target config.Target, versionOnly bool) {
 	defer wg.Done()
 
-	slog.Info("Scanning target.", "name", name)
+	if versionOnly {
+		slog.Info("Scanning target for Version Only.", "name", name)
+	} else {
+		slog.Info("Scanning target for Licenses.", "name", name)
+	}
 
 	keyPath := os.ExpandEnv(config.Conf.Common.SSHKeyPath)
 	keyBytes, err := os.ReadFile(keyPath)
@@ -166,15 +170,23 @@ done
 	case "windows":
 		message := fmt.Sprintf("Detected OS: %s", targetOS)
 		slog.Info(message)
+		if versionOnly {
+			output, err := runCommand(client, `foreach ($UKey in 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*','HKLM:\SOFTWARE\Wow6432node\Microsoft\Windows\CurrentVersion\Uninstall\*','HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*','HKCU:\SOFTWARE\Wow6432node\Microsoft\Windows\CurrentVersion\Uninstall\*'){foreach ($Product in (Get-ItemProperty $UKey -ErrorAction SilentlyContinue)){if($Product.DisplayName -and $Product.SystemComponent -ne 0){$Product.DisplayName + "|&|" + $Product.DisplayVersion}}}`)
 
-		output, err := runCommand(client, `foreach ($UKey in 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*','HKLM:\SOFTWARE\Wow6432node\Microsoft\Windows\CurrentVersion\Uninstall\*','HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*','HKCU:\SOFTWARE\Wow6432node\Microsoft\Windows\CurrentVersion\Uninstall\*'){foreach ($Product in (Get-ItemProperty $UKey -ErrorAction SilentlyContinue)){if($Product.DisplayName -and $Product.SystemComponent -ne 0){$Product.DisplayName + "|&|" + $Product.DisplayVersion}}}`)
+			if err != nil {
+				slog.Error("Failed to query packages.")
+				return
+			}
 
-		if err != nil {
-			slog.Error("Failed to query packages.")
-			return
+			parseWIN(string(output), licenseInfo)
+		} else {
+			message := fmt.Sprintf("Windows OS is not supported for Licenses Scanning: %s", targetOS)
+			slog.Error(message)
+
+			singleError := models.SingleError{TargetName: name, Error: models.Error{Time: time.Now(), Level: models.Critical, Message: message}}
+			errorsCh <- singleError
 		}
 
-		parseWIN(string(output), licenseInfo)
 	case "macos":
 		message := fmt.Sprintf("MacOS is not supported yet: %s", targetOS)
 		slog.Error(message)

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -7,6 +7,7 @@
 package scanner
 
 import (
+	"fmt"
 	"log/slog"
 	"net"
 	"os"
@@ -26,25 +27,29 @@ type Scanner struct {
 	Targets map[string]config.Target
 }
 
+var wg sync.WaitGroup
+var resultsCh chan models.SingleResult
+var errorsCh chan models.SingleError
+
 // Scan execute scan
 func (s Scanner) Scan() error {
-	var wg sync.WaitGroup
-
 	scanResult := models.ScanResult{
 		Version:   config.Version,
 		ScannedAt: time.Now().Format("2006-01-02T15:04:05"),
 		Results:   make(models.LicenseInfos),
+		Errors:    make(models.Errors),
 	}
 
-	resultsCh := make(chan models.SingleResult, len(s.Targets))
-
-	wg.Add(1)
-	go s.collectResults(&scanResult, resultsCh, &wg)
+	resultsCh = make(chan models.SingleResult, len(s.Targets))
+	errorsCh = make(chan models.SingleError, len(s.Targets))
 
 	for name, target := range s.Targets {
 		wg.Add(1)
-		go scanTarget(name, target, resultsCh, &wg)
+		go scanTarget(name, target)
 	}
+
+	go s.collectResults(&scanResult)
+	go s.collectErrors(&scanResult)
 
 	wg.Wait()
 
@@ -52,7 +57,7 @@ func (s Scanner) Scan() error {
 	return nil
 }
 
-func scanTarget(name string, target config.Target, resultsCh chan models.SingleResult, wg *sync.WaitGroup) {
+func scanTarget(name string, target config.Target) {
 	defer wg.Done()
 
 	slog.Info("Scanning target.", "name", name)
@@ -96,6 +101,9 @@ func scanTarget(name string, target config.Target, resultsCh chan models.SingleR
 
 	switch targetOS := getTargetOS(client); targetOS {
 	case "fedora", "opensuse-leap", "centos", "rhel", "rocky":
+		message := fmt.Sprintf("Detected OS: %s", targetOS)
+		slog.Info(message)
+
 		output, err := runCommand(client, `rpm -qa --queryformat "%{NAME} %{LICENSE}\n"`)
 
 		if err != nil {
@@ -104,6 +112,12 @@ func scanTarget(name string, target config.Target, resultsCh chan models.SingleR
 		}
 
 		parseRPM(string(output), licenseInfo)
+	default:
+		message := fmt.Sprintf("Unsupported OS: %s", targetOS)
+		slog.Error(message)
+
+		singleError := models.SingleError{TargetName: name, Error: models.Error{Time: time.Now(), Level: models.Critical, Message: message}}
+		errorsCh <- singleError
 	}
 
 	resultsCh <- models.SingleResult{TargetName: name, LicenseInfo: licenseInfo}
@@ -111,16 +125,15 @@ func scanTarget(name string, target config.Target, resultsCh chan models.SingleR
 	slog.Info("Finished scanning.", "name", name)
 }
 
-func (s Scanner) collectResults(scanResult *models.ScanResult, resultsCh chan models.SingleResult, wg *sync.WaitGroup) {
-	defer wg.Done()
-	i := 0
-
+func (s Scanner) collectResults(scanResult *models.ScanResult) {
 	for singleResult := range resultsCh {
 		scanResult.Results[singleResult.TargetName] = singleResult.LicenseInfo
-		i++
-		if i == len(s.Targets) {
-			break
-		}
+	}
+}
+
+func (s Scanner) collectErrors(scanResult *models.ScanResult) {
+	for scanError := range errorsCh {
+		scanResult.Errors[scanError.TargetName] = scanError.Error
 	}
 }
 

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -24,7 +24,8 @@ import (
 )
 
 type Scanner struct {
-	Targets map[string]config.Target
+	Targets     map[string]config.Target
+	VersionOnly bool
 }
 
 var wg sync.WaitGroup
@@ -35,9 +36,14 @@ var errorsCh chan models.SingleError
 func (s Scanner) Scan() error {
 	scanResult := models.ScanResult{
 		Version:   config.Version,
+		ScanMode:  "License",
 		ScannedAt: time.Now().Format("2006-01-02T15:04:05"),
 		Results:   make(models.LicenseInfos),
 		Errors:    make(models.TargetErrors),
+	}
+
+	if s.VersionOnly {
+		scanResult.ScanMode = "Version"
 	}
 
 	resultsCh = make(chan models.SingleResult, len(s.Targets))
@@ -45,7 +51,7 @@ func (s Scanner) Scan() error {
 
 	for name, target := range s.Targets {
 		wg.Add(1)
-		go scanTarget(name, target)
+		go scanTarget(name, target, s.VersionOnly)
 	}
 
 	go s.collectResults(&scanResult)
@@ -57,7 +63,7 @@ func (s Scanner) Scan() error {
 	return nil
 }
 
-func scanTarget(name string, target config.Target) {
+func scanTarget(name string, target config.Target, versionOnly bool) {
 	defer wg.Done()
 
 	slog.Info("Scanning target.", "name", name)
@@ -104,7 +110,13 @@ func scanTarget(name string, target config.Target) {
 		message := fmt.Sprintf("Detected OS: %s", targetOS)
 		slog.Info(message)
 
-		output, err := runCommand(client, `rpm -qa --queryformat "%{NAME} %{LICENSE}\n"`)
+		rpm_cmd := `rpm -qa --queryformat "%{NAME} %{LICENSE}\n"`
+
+		if versionOnly {
+			rpm_cmd = `rpm -qa --queryformat "%{NAME} %{VERSION}\n"`
+		}
+
+		output, err := runCommand(client, rpm_cmd)
 
 		if err != nil {
 			slog.Error("Failed to query packages.")
@@ -116,6 +128,15 @@ func scanTarget(name string, target config.Target) {
 		message := fmt.Sprintf("Detected OS: %s", targetOS)
 		slog.Info(message)
 
+		dpkg_cmd := dpkg_name_lic
+
+		if versionOnly {
+			dpkg_cmd = `COLUMNS=2000 dpkg -l | grep '^.[iufhwt]' | while read pState package pVer pArch pDesc; do
+printf "$package $pVer\n"
+done
+`
+		}
+
 		output, err := runCommand(client, dpkg_cmd)
 
 		if err != nil {
@@ -124,6 +145,10 @@ func scanTarget(name string, target config.Target) {
 		}
 
 		parseDPKG(string(output), licenseInfo)
+
+		if versionOnly {
+			break
+		}
 
 		failed := 0
 		for _, license := range licenseInfo {

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -181,7 +181,7 @@ done
 
 			parseWIN(string(output), licenseInfo)
 		} else {
-			message := fmt.Sprintf("Windows OS is not supported for Licenses Scanning: %s", targetOS)
+			message := "Windows OS is not supported for Licenses Scanning."
 			slog.Error(message)
 
 			singleError := models.SingleError{TargetName: name, Error: models.Error{Time: time.Now(), Level: models.Critical, Message: message}}
@@ -230,7 +230,8 @@ func runCommand(client *ssh.Client, command string) ([]byte, error) {
 	output, err := session.Output(command)
 
 	if err != nil {
-		slog.Error("failed to start command", "command", command, "error", err)
+		// Removing the logging here because it is handled at the otehr side.
+		// 	slog.Error("failed to start command", "command", command, "error", err)
 		return nil, err
 	}
 

--- a/subcmds/scan.go
+++ b/subcmds/scan.go
@@ -21,7 +21,8 @@ import (
 )
 
 type ScanCmd struct {
-	localhost bool
+	localhost   bool
+	versionOnly bool
 }
 
 func (*ScanCmd) Name() string { return "scan" }
@@ -36,6 +37,7 @@ func (*ScanCmd) Usage() string {
 
 func (p *ScanCmd) SetFlags(f *flag.FlagSet) {
 	f.BoolVar(&p.localhost, "localhost", false, "Scan localhost only.")
+	f.BoolVar(&p.versionOnly, "only-version", false, "Scan package name and version only.")
 }
 
 func (p *ScanCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
@@ -54,7 +56,8 @@ func (p *ScanCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) 
 	targets := config.Conf.Targets
 
 	s := scanner.Scanner{
-		Targets: targets,
+		Targets:     targets,
+		VersionOnly: p.versionOnly,
 	}
 
 	if p.localhost {

--- a/subcmds/scan.go
+++ b/subcmds/scan.go
@@ -11,6 +11,7 @@ import (
 	"flag"
 	"log/slog"
 	"os"
+	"time"
 
 	"github.com/yaltf/yaltf/config"
 	"github.com/yaltf/yaltf/logging"
@@ -57,6 +58,7 @@ func (p *ScanCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) 
 
 	s := scanner.Scanner{
 		Targets:     targets,
+		Timeout:     time.Duration(config.Conf.Common.SSHTimeout),
 		VersionOnly: p.versionOnly,
 	}
 

--- a/subcmds/scan.go
+++ b/subcmds/scan.go
@@ -66,7 +66,11 @@ func (p *ScanCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) 
 		s.Scan()
 	}
 
-	logging.InfoLog.Print("Scan finished.")
+	if p.versionOnly {
+		logging.InfoLog.Print("Scan for versions finished.")
+	} else {
+		logging.InfoLog.Print("Scan for licenses finished.")
+	}
 
 	return subcommands.ExitSuccess
 }

--- a/subcmds/scan.go
+++ b/subcmds/scan.go
@@ -51,7 +51,7 @@ func (p *ScanCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) 
 		os.Exit(1)
 	}
 
-	logging.InfoLog.Print("Start scanning.")
+	logging.InfoLog.Print("Scanning started.")
 
 	targets := config.Conf.Targets
 
@@ -67,9 +67,9 @@ func (p *ScanCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) 
 	}
 
 	if p.versionOnly {
-		logging.InfoLog.Print("Scan for versions finished.")
+		logging.InfoLog.Print("Scanning for versions on all targets finished.")
 	} else {
-		logging.InfoLog.Print("Scan for licenses finished.")
+		logging.InfoLog.Print("Scanning for licenses on all targets finished.")
 	}
 
 	return subcommands.ExitSuccess

--- a/subcmds/scan.go
+++ b/subcmds/scan.go
@@ -37,7 +37,7 @@ func (*ScanCmd) Usage() string {
 
 func (p *ScanCmd) SetFlags(f *flag.FlagSet) {
 	f.BoolVar(&p.localhost, "localhost", false, "Scan localhost only.")
-	f.BoolVar(&p.versionOnly, "only-version", false, "Scan package name and version only.")
+	f.BoolVar(&p.versionOnly, "version-only", false, "Scan package name and version only.")
 }
 
 func (p *ScanCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {


### PR DESCRIPTION
In general, there could obviously be some tweaks needed here and there, however, as mentioned by ziya, If merged, the below could close Issues 4, 5, 6, 8, 9 and partially address Issue #7 (and I believe partially #10 since the scanner is there for versions but not licenses)
* better logging and error handling
* added OS identification for debian, ubuntu, windows
* licenses scanning for installed software on debian based OSs; tested Debian and Kubuntu (this is a workaround because of the fact that licenses are not straight forward in debian-based Oss; the workaround scans licenses files for possible compatibilities with usual licenses and concatenates that in the result with 75% success rate according to Ziya which can be improved in the future)
* versions scanning for installed software on debian based, RHEL based and Windows (by version scanning we mean, instead of outputting a json file with "name/license", we output a json file with "name/version"; this will hopefully help with vulnerability detection)
* timeout controls is now in the configuration
